### PR TITLE
add subxt module call logic to node

### DIFF
--- a/modules/vote-yesno/src/tests.rs
+++ b/modules/vote-yesno/src/tests.rs
@@ -63,13 +63,8 @@ fn vote_1p1v_created_correctly() {
     new_test_ext().execute_with(|| {
         let one = Origin::signed(1);
 
-        let one_person_one_vote = SupportedVoteTypes::OneAccountOneVote;
-        assert_ok!(VoteYesNo::create_count_threshold_vote(
-            one,
-            1,
-            1,
-            one_person_one_vote,
-            3u64, // just requires 3 votes in favor
+        assert_ok!(VoteYesNo::create_1p1v_count_threshold_vote(
+            one, 1, 1, 3u64, // just requires 3 votes in favor
             0u64,
         ));
 
@@ -93,11 +88,10 @@ fn vote_1p1v_apply_correctly() {
         let one = Origin::signed(1);
 
         // 1 creates a vote for share group 1 in organization 1
-        assert_ok!(VoteYesNo::create_count_threshold_vote(
+        assert_ok!(VoteYesNo::create_1p1v_count_threshold_vote(
             one.clone(),
             1,
             1,
-            SupportedVoteTypes::OneAccountOneVote,
             3u64, // just requires 3 votes in favor
             0u64,
         ));
@@ -207,11 +201,10 @@ fn vote_1p1v_threshold_enforced_correctly() {
         let one = Origin::signed(1);
 
         // 1 creates a vote for share group 1 in organization 1
-        assert_ok!(VoteYesNo::create_count_threshold_vote(
+        assert_ok!(VoteYesNo::create_1p1v_count_threshold_vote(
             one.clone(),
             1,
             1,
-            SupportedVoteTypes::OneAccountOneVote,
             5u64,
             0u64,
         ));
@@ -244,11 +237,10 @@ fn vote_1p1v_threshold_enforced_correctly() {
         assert_eq!(first_vote_outcome, Outcome::Approved);
 
         // 1 creates a vote for share group 2 in organization 1
-        assert_ok!(VoteYesNo::create_count_threshold_vote(
+        assert_ok!(VoteYesNo::create_1p1v_count_threshold_vote(
             one.clone(),
             1,
             2,
-            SupportedVoteTypes::OneAccountOneVote,
             1,
             0,
         ));
@@ -279,11 +271,10 @@ fn vote_1p1v_threshold_enforced_correctly() {
         assert_eq!(second_vote_outcome, Outcome::Approved);
 
         // 1 creates another vote for share group 1 in organization 1
-        assert_ok!(VoteYesNo::create_count_threshold_vote(
+        assert_ok!(VoteYesNo::create_1p1v_count_threshold_vote(
             one.clone(),
             1,
             1,
-            SupportedVoteTypes::OneAccountOneVote,
             3,
             0,
         ));
@@ -318,12 +309,10 @@ fn vote_share_weighted_created_correctly() {
     new_test_ext().execute_with(|| {
         let one = Origin::signed(1);
 
-        let share_weighted_vote = SupportedVoteTypes::ShareWeighted;
-        assert_ok!(VoteYesNo::create_percentage_threshold_vote(
+        assert_ok!(VoteYesNo::create_share_weighted_percentage_threshold_vote(
             one,
             1,
             1,
-            share_weighted_vote,
             Permill::from_percent(51),
             Permill::from_percent(10)
         ));
@@ -348,11 +337,10 @@ fn vote_share_weighted_apply_correctly() {
         let one = Origin::signed(1);
 
         // 1 creates a vote for share group 1 in organization 1
-        assert_ok!(VoteYesNo::create_percentage_threshold_vote(
+        assert_ok!(VoteYesNo::create_share_weighted_percentage_threshold_vote(
             one.clone(),
             1,
             1,
-            SupportedVoteTypes::ShareWeighted,
             Permill::from_percent(51),
             Permill::from_percent(10)
         ));
@@ -462,11 +450,10 @@ fn vote_share_weighted_threshold_enforced_correctly() {
         let one = Origin::signed(1);
 
         // 1 creates a vote for share group 1 in organization 1
-        assert_ok!(VoteYesNo::create_percentage_threshold_vote(
+        assert_ok!(VoteYesNo::create_share_weighted_percentage_threshold_vote(
             one.clone(),
             1,
             1,
-            SupportedVoteTypes::ShareWeighted,
             Permill::from_percent(51),
             Permill::from_percent(10)
         ));
@@ -499,11 +486,10 @@ fn vote_share_weighted_threshold_enforced_correctly() {
         assert_eq!(first_vote_outcome, Outcome::Approved);
 
         // 1 creates a vote for share group 2 in organization 1
-        assert_ok!(VoteYesNo::create_percentage_threshold_vote(
+        assert_ok!(VoteYesNo::create_share_weighted_percentage_threshold_vote(
             one.clone(),
             1,
             2,
-            SupportedVoteTypes::ShareWeighted,
             Permill::from_percent(33),
             Permill::from_percent(10)
         ));
@@ -532,11 +518,10 @@ fn vote_share_weighted_threshold_enforced_correctly() {
         assert_eq!(second_vote_outcome, Outcome::Approved);
 
         // 1 creates another vote for share group 1 in organization 1
-        assert_ok!(VoteYesNo::create_percentage_threshold_vote(
+        assert_ok!(VoteYesNo::create_share_weighted_percentage_threshold_vote(
             one.clone(),
             1,
             1,
-            SupportedVoteTypes::ShareWeighted,
             Permill::from_percent(33),
             Permill::from_percent(10)
         ));

--- a/node/src/subxt/mod.rs
+++ b/node/src/subxt/mod.rs
@@ -1,0 +1,2 @@
+pub mod vote_yesno;
+pub mod shares_atomic;

--- a/node/src/subxt/shares_atomic.rs
+++ b/node/src/subxt/shares_atomic.rs
@@ -1,0 +1,55 @@
+use crate::frame::{system::System, Call};
+use codec::Codec;
+use frame_support::Parameter;
+use sp_runtime::traits::{AtLeast32Bit, MaybeSerializeDeserialize, Member, Zero};
+use std::fmt::Debug;
+
+/// The subset of the `shares_atomic::Trait` that a client must implement.
+pub trait SharesAtomic: System {
+    type OrgId: Parameter
+        + Member
+        + AtLeast32Bit
+        + Codec
+        + Default
+        + Copy
+        + MaybeSerializeDeserialize
+        + Debug
+        + Zero;
+
+    type ShareId: Parameter
+        + Member
+        + AtLeast32Bit
+        + Codec
+        + Default
+        + Copy
+        + MaybeSerializeDeserialize
+        + Debug;
+}
+
+const MODULE: &str = "SharesAtomic";
+const RESERVE: &str = "reserve_shares";
+
+/// Arguments for requesting a share reservation
+#[derive(codec::Encode)]
+pub struct ReserveArgs<T: SharesAtomic> {
+    org: T::OrgId,
+    share: T::ShareId,
+    account: <T as System>::AccountId,
+}
+
+/// Request the share reservation
+pub fn reserve_shares<T: SharesAtomic>(
+    org: T::OrgId,
+    share: T::ShareId,
+    account: <T as System>::AccountId,
+) -> Call<ReserveArgs<T>> {
+    Call::new(
+        MODULE,
+        RESERVE,
+        ReserveArgs {
+            org,
+            share,
+            account,
+        },
+    )
+}

--- a/node/src/subxt/vote_yesno.rs
+++ b/node/src/subxt/vote_yesno.rs
@@ -1,0 +1,179 @@
+//! Implements support for the vote_yesno module
+
+use crate::frame::{system::System, Call};
+use codec::Codec;
+use frame_support::Parameter;
+use sp_runtime::{
+    traits::{AtLeast32Bit, MaybeSerializeDeserialize, Member, Zero},
+    Permill,
+};
+use std::fmt::Debug;
+use util::{
+    traits::{GroupMembership, LockableProfile, ReservableProfile, ShareBank, ShareRegistration},
+    voteyesno::VoterYesNoView,
+};
+
+/// The subset of the `vote_yesno::Trait` that a client must implement.
+pub trait VoteYesNo: System {
+    /// The identifier for each vote; ProposalId => Vec<VoteId> s.t. sum(VoteId::Outcomes) => ProposalId::Outcome
+    type VoteId: Parameter
+        + Member
+        + AtLeast32Bit
+        + Codec
+        + Default
+        + Copy
+        + MaybeSerializeDeserialize
+        + Debug;
+
+    /// The native type for vote strength
+    type Signal: Parameter
+        + Member
+        + AtLeast32Bit
+        + Codec
+        + Default
+        + Copy
+        + MaybeSerializeDeserialize
+        + Debug
+        + Zero;
+
+    /// An instance of the shares module
+    type ShareData: GroupMembership<Self::AccountId>
+        + ShareRegistration<Self::AccountId>
+        + ReservableProfile<Self::AccountId>
+        + LockableProfile<Self::AccountId>
+        + ShareBank<Self::AccountId>;
+}
+
+/// The share identifier type
+pub type ShareId<T> =
+    <<T as VoteYesNo>::ShareData as ShareRegistration<<T as System>::AccountId>>::ShareId;
+
+/// The organization identifier type
+pub type OrgId<T> =
+    <<T as VoteYesNo>::ShareData as ShareRegistration<<T as System>::AccountId>>::OrgId;
+
+const MODULE: &str = "VoteYesNo";
+const CREATE_SHARE_WEIGHTED_PERCENTAGE_VOTE_NO_EXPIRY: &str =
+    "create_share_weighted_percentage_threshold_vote";
+const CREATE_SHARE_WEIGHTED_COUNT_VOTE_NO_EXPIRY: &str =
+    "create_share_weighted_count_threshold_vote";
+const CREATE_1P1V_COUNT_VOTE_NO_EXPIRY: &str = "create_1p1v_count_threshold_vote";
+const SUBMIT_VOTE: &str = "submit_vote";
+
+/// Arguments for creating a share weighted vote with thresholds based on percents
+#[derive(codec::Encode)]
+pub struct CreateShareWeightedPercentageVoteArgs<T: VoteYesNo> {
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    passage_threshold_pct: Permill,
+    turnout_threshold_pct: Permill,
+}
+
+/// Arguments for creating a share weighted vote with thresholds based on signal amounts
+#[derive(codec::Encode)]
+pub struct CreateShareWeightedCountVoteArgs<T: VoteYesNo> {
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    support_requirement: T::Signal,
+    turnout_requirement: T::Signal,
+}
+
+/// Arguments for creating a 1p1v vote with thresholds based on signal amounts
+#[derive(codec::Encode)]
+pub struct Create1P1VCountVoteArgs<T: VoteYesNo> {
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    support_requirement: T::Signal,
+    turnout_requirement: T::Signal,
+}
+
+/// Arguments for submitting a vote
+#[derive(codec::Encode)]
+pub struct SubmitVoteArgs<T: VoteYesNo> {
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    vote_id: T::Signal,
+    voter: <T as System>::AccountId,
+    direction: VoterYesNoView,
+    magnitude: Option<T::Signal>,
+}
+
+/// Create share weighted percentage threshold vote in the context of an organizational share group
+pub fn create_share_weighted_percentage_vote<T: VoteYesNo>(
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    passage_threshold_pct: Permill,
+    turnout_threshold_pct: Permill,
+) -> Call<CreateShareWeightedPercentageVoteArgs<T>> {
+    Call::new(
+        MODULE,
+        CREATE_SHARE_WEIGHTED_PERCENTAGE_VOTE_NO_EXPIRY,
+        CreateShareWeightedPercentageVoteArgs {
+            organization,
+            share_id,
+            passage_threshold_pct,
+            turnout_threshold_pct,
+        },
+    )
+}
+
+/// Create share weighted count threshold vote in the context of an organizational share group
+pub fn create_share_weighted_count_vote<T: VoteYesNo>(
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    support_requirement: T::Signal,
+    turnout_requirement: T::Signal,
+) -> Call<CreateShareWeightedCountVoteArgs<T>> {
+    Call::new(
+        MODULE,
+        CREATE_SHARE_WEIGHTED_COUNT_VOTE_NO_EXPIRY,
+        CreateShareWeightedCountVoteArgs {
+            organization,
+            share_id,
+            support_requirement,
+            turnout_requirement,
+        },
+    )
+}
+
+/// Create 1 account 1 vote count threshold vote in the context of an organizational share group
+pub fn create_1p1v_count_vote<T: VoteYesNo>(
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    support_requirement: T::Signal,
+    turnout_requirement: T::Signal,
+) -> Call<Create1P1VCountVoteArgs<T>> {
+    Call::new(
+        MODULE,
+        CREATE_1P1V_COUNT_VOTE_NO_EXPIRY,
+        Create1P1VCountVoteArgs {
+            organization,
+            share_id,
+            support_requirement,
+            turnout_requirement,
+        },
+    )
+}
+
+/// Submits a vote
+pub fn submit_vote<T: VoteYesNo>(
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    vote_id: T::Signal,
+    voter: <T as System>::AccountId,
+    direction: VoterYesNoView,
+    magnitude: Option<T::Signal>,
+) -> Call<SubmitVoteArgs<T>> {
+    Call::new(
+        MODULE,
+        SUBMIT_VOTE,
+        SubmitVoteArgs {
+            organization,
+            share_id,
+            vote_id,
+            voter,
+            direction,
+            magnitude,
+        },
+    )
+}

--- a/node/src/subxt/vote_yesno.rs
+++ b/node/src/subxt/vote_yesno.rs
@@ -57,6 +57,7 @@ const CREATE_SHARE_WEIGHTED_PERCENTAGE_VOTE_NO_EXPIRY: &str =
     "create_share_weighted_percentage_threshold_vote";
 const CREATE_SHARE_WEIGHTED_COUNT_VOTE_NO_EXPIRY: &str =
     "create_share_weighted_count_threshold_vote";
+const CREATE_1P1V_PERCENTAGE_VOTE_NO_EXPIRY: &str = "create_1p1v_share_weighted_threshold_vote";
 const CREATE_1P1V_COUNT_VOTE_NO_EXPIRY: &str = "create_1p1v_count_threshold_vote";
 const SUBMIT_VOTE: &str = "submit_vote";
 
@@ -65,8 +66,8 @@ const SUBMIT_VOTE: &str = "submit_vote";
 pub struct CreateShareWeightedPercentageVoteArgs<T: VoteYesNo> {
     organization: OrgId<T>,
     share_id: ShareId<T>,
-    passage_threshold_pct: Permill,
-    turnout_threshold_pct: Permill,
+    support_requirement: Permill,
+    turnout_requirement: Permill,
 }
 
 /// Arguments for creating a share weighted vote with thresholds based on signal amounts
@@ -76,6 +77,15 @@ pub struct CreateShareWeightedCountVoteArgs<T: VoteYesNo> {
     share_id: ShareId<T>,
     support_requirement: T::Signal,
     turnout_requirement: T::Signal,
+}
+
+/// Arguments for creating a 1p1v vote with thresholds based on signal amounts
+#[derive(codec::Encode)]
+pub struct Create1P1VPercentageVoteArgs<T: VoteYesNo> {
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    support_requirement: Permill,
+    turnout_requirement: Permill,
 }
 
 /// Arguments for creating a 1p1v vote with thresholds based on signal amounts
@@ -102,8 +112,8 @@ pub struct SubmitVoteArgs<T: VoteYesNo> {
 pub fn create_share_weighted_percentage_vote<T: VoteYesNo>(
     organization: OrgId<T>,
     share_id: ShareId<T>,
-    passage_threshold_pct: Permill,
-    turnout_threshold_pct: Permill,
+    support_requirement: Permill,
+    turnout_requirement: Permill,
 ) -> Call<CreateShareWeightedPercentageVoteArgs<T>> {
     Call::new(
         MODULE,
@@ -111,8 +121,8 @@ pub fn create_share_weighted_percentage_vote<T: VoteYesNo>(
         CreateShareWeightedPercentageVoteArgs {
             organization,
             share_id,
-            passage_threshold_pct,
-            turnout_threshold_pct,
+            support_requirement,
+            turnout_requirement,
         },
     )
 }
@@ -128,6 +138,25 @@ pub fn create_share_weighted_count_vote<T: VoteYesNo>(
         MODULE,
         CREATE_SHARE_WEIGHTED_COUNT_VOTE_NO_EXPIRY,
         CreateShareWeightedCountVoteArgs {
+            organization,
+            share_id,
+            support_requirement,
+            turnout_requirement,
+        },
+    )
+}
+
+/// Create share weighted count threshold vote in the context of an organizational share group
+pub fn create_1p1v_percentage_vote<T: VoteYesNo>(
+    organization: OrgId<T>,
+    share_id: ShareId<T>,
+    support_requirement: T::Signal,
+    turnout_requirement: T::Signal,
+) -> Call<Create1P1VPercentageVoteArgs<T>> {
+    Call::new(
+        MODULE,
+        CREATE_1P1V_PERCENTAGE_VOTE_NO_EXPIRY,
+        Create1P1VPercentageVoteArgs {
             organization,
             share_id,
             support_requirement,


### PR DESCRIPTION
@dvc94ch I put the call logic for substrate-subxt in `node/src/subxt` and I'm thinking of trying to configure SubstrateCLI so that it uses these calls to form the transactions and submit it directly to the node. 

This way we can just call the node instead of calling substrate-subxt to communicate with the node over RPC...