### PR TITLE
Add pm2 configuration for Starting/Stopping Development Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,14 @@ Start a development chain with:
 ```
 
 Detailed logs may be shown by running the node with the following environment variables set: `RUST_LOG=debug RUST_BACKTRACE=1 cargo run -- --dev`.
+
+### Run dev chain with [pm2][pm2]
+
+```
+pm2 start scripts/daemon.json
+```
+
+The will raise a `sunsine-node` process background on yor machine, to checkout the `sunshine-node` outputs, run `pm2 log sunshine-node`.
+
+
+[pm2]: https://pm2.keymetrics.io/

--- a/scripts/daemon.json
+++ b/scripts/daemon.json
@@ -1,0 +1,8 @@
+{
+  "apps": [
+    {
+      "name": "sunshine-node",
+      "script": "target/debug/sunshine-node --dev"
+    }
+  ]
+}


### PR DESCRIPTION
#35 

---

## What is `pm2`?

A process manager which is written in `node.js`

### Installation

```shell
# use npm
npm i -g pm2 

# use yarn
yarn global add pm2
```

## How to run the `scripts/daemon.json`?

```shell
pm2 start scripts/daemon.json
```

This will start the developing node background, and you can

```shell
# show the log of sunshine-node
pm2 log sunshine-node

# stop sunshine-node
pm2 stop sunshine-node

# restart sunshine-node
pm2 restart sunshine-node
```

We just need to run `pm2 start scripts/daemon.json`for once, and pm2 will record the `sunshine-node` process, after that, we can just 

```shell
pm2 start sunshine-node
```

Without any other `under-directory` operating.
